### PR TITLE
Where does not take strings, but field ids

### DIFF
--- a/src/query/RestrictionGroup.php
+++ b/src/query/RestrictionGroup.php
@@ -4,6 +4,7 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use spitfire\collection\Collection;
 use spitfire\exceptions\ApplicationException;
+use spitfire\storage\database\identifiers\FieldIdentifier;
 use spitfire\storage\database\identifiers\TableIdentifierInterface;
 use spitfire\storage\database\Query;
 
@@ -59,13 +60,13 @@ class RestrictionGroup
 	 *
 	 * @see  http://www.spitfirephp.com/wiki/index.php/Method:spitfire/storage/database/Query::addRestriction
 	 *
-	 * @param string $field
-	 * @param mixed  $value
-	 * @param mixed  $_
+	 * @param FieldIdentifier $field
+	 * @param mixed $value
+	 * @param mixed $_
 	 * @return RestrictionGroup
 	 * @throws ApplicationException
 	 */
-	public function where($field, $value, $_ = null) : RestrictionGroup
+	public function where(FieldIdentifier $field, $value, $_ = null) : RestrictionGroup
 	{
 		$params = func_num_args();
 		
@@ -81,7 +82,7 @@ class RestrictionGroup
 		}
 		
 		
-		$this->restrictions->push(new Restriction($this->table->getOutput($field), $operator, $value));
+		$this->restrictions->push(new Restriction($field, $operator, $value));
 		return $this;
 	}
 	

--- a/tests/grammar/mysql/MySQLQueryGrammarTest.php
+++ b/tests/grammar/mysql/MySQLQueryGrammarTest.php
@@ -99,7 +99,7 @@ class MySQLQueryGrammarTest extends TestCase
 		$query->whereExists(function (TableIdentifier $parent) use ($layout2) {
 			$sq = new Query($layout2->getTableReference());
 			$sq->select('testfield');
-			$sq->where('teststring', $parent->getOutput('teststring'));
+			$sq->where($sq->table()->getOutput('teststring'), $parent->getOutput('teststring'));
 			return $sq;
 		});
 		


### PR DESCRIPTION
This prevents the database from being locked to a single table when we're performing operations not unlike joins